### PR TITLE
chore: Upgrade Vert.x to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,8 +102,8 @@
         <slf4j.version>1.7.21</slf4j.version>
         <spring.version>4.3.3.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
-	<vertx.version>3.5.0</vertx.version>
-        <netty.version>4.1.15.Final</netty.version>
+	<vertx.version>3.5.1</vertx.version>
+        <netty.version>4.1.19.Final</netty.version>
         <logback.version>1.1.7</logback.version>
         <mockito.version>1.10.19</mockito.version>
         <jackson.version>2.8.4</jackson.version>


### PR DESCRIPTION
Closes gravitee-io/issues#351