### PR TITLE
chore: update mockito to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <jetty.version>9.4.28.v20200408</jetty.version>
         <jersey.version>2.30.1</jersey.version>
         <logback.version>1.2.3</logback.version>
-        <mockito.version>2.24.5</mockito.version>
+        <mockito.version>3.6.0</mockito.version>
         <jackson.version>2.10.3</jackson.version>
         <rxjava.version>2.2.19</rxjava.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>


### PR DESCRIPTION
Fixes https://github.com/gravitee-io/issues/issues/5236
