### PR TITLE
chore: Update vert.x library to 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <spring.version>5.2.6.RELEASE</spring.version>
         <junit.version>4.12</junit.version>
-        <vertx.version>3.8.5</vertx.version>
+        <vertx.version>3.9.6</vertx.version>
         <netty.version>4.1.49.Final</netty.version>
         <jetty.version>9.4.28.v20200408</jetty.version>
         <jersey.version>2.30.1</jersey.version>


### PR DESCRIPTION
Closes gravitee-io/issues#4095