### PR TITLE
Cicd/circleci pipeline def

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,96 @@
+version: 2.1
+
+parameters:
+  gio_action:
+    type: enum
+    enum: [release, pull_requests]
+    default: pull_requests
+  dry_run:
+    type: boolean
+    default: true
+    description: "Run in dry run mode?"
+  maven_profile_id:
+    type: string
+    default: "gravitee-dry-run"
+    description: "Maven ID of the Maven profile to use for a dry run ?"
+  next_snapshot_version:
+    type: string
+    default: $NEXT_SNAPSHOT_VERSION
+    description: "Used only for the Gravitee Parent Release Process: What will be the next snapshot version?"
+  secrethub_org:
+    type: string
+    default: "gravitee-lab"
+    description: "SecretHub Org to use to fetch secrets ?"
+  secrethub_repo:
+    type: string
+    default: "cicd"
+    description: "SecretHub Repo to use to fetch secrets ?"
+
+orbs:
+  gravitee: gravitee-io/gravitee@dev:1.0.4
+  secrethub: secrethub/cli@1.1.0
+
+# --- Jobs to perform all workflows
+# jobs:
+
+
+workflows:
+  version: 2.1
+  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
+  pull_requests:
+    when:
+      and:
+        - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/d_pull_requests_secrets:
+          context: cicd-orchestrator
+          name: pr_secrets_resolution
+      - gravitee/d_pull_requests_ce:
+          name: publish_snapshot
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
+          maven_profile_id: 'gio-dev'
+          # nexus_snapshots_url: 'https://oss.sonatype.org/content/repositories/snapshots'
+          # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'xlarge'
+          # filters:
+            # branches:
+              # ignore:
+                # - master
+                # # - /^[0-999].[0-999].x/ # Ignore support branches, because they are checked with noightly ? Would make sense...
+
+  release:
+    when:
+      and:
+        - equal: [ release, << pipeline.parameters.gio_action >> ]
+        - not : << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_gio_parent_release_secrets:
+          context: cicd-orchestrator
+          name: 'gio_parent_release_secrets'
+      - gravitee/d_gio_parent_release:
+          requires:
+            - gio_parent_release_secrets
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: 'gio-release'
+          next_snapshot_version: << pipeline.parameters.next_snapshot_version >>
+
+  release_dry_run:
+    when:
+      and:
+        - equal: [ release, << pipeline.parameters.gio_action >> ]
+        - << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_gio_parent_release_secrets:
+          context: cicd-orchestrator
+          name: 'gio_parent_release_secrets'
+      - gravitee/d_gio_parent_release:
+          requires:
+            - gio_parent_release_secrets
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: 'gravitee-dry-run'
+          next_snapshot_version: << pipeline.parameters.next_snapshot_version >>


### PR DESCRIPTION
The provided Circle CI Pipeline definition : 
* manages the release process : 
  * tested valid with : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-parent/60/workflows/88fea470-429d-4f18-8084-f3fe45eaa78e
  * documented at https://github.com/gravitee-io/kb/wiki/CICD:-The-Gravitee-Parent#gravitee-parent-releases
  * can be used to release `19.2.3` `gravitee-parent` (eg used on master of Gravitee AM)
  * Pipeline has exact same parameters as the Legacy Jenkins _Gravitee Parent Release_
* manages publishing the SNAPSHOT version , triggered by any git pushed commit on any git branch : 
  * tested valid with : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-parent/61/workflows/2acd54b7-bb56-47c0-a77e-89d708a607ca


Note : exact same `.circleci/config.yml` can be used on all git branches of this repô 