### PR TITLE
chore: bump maven-surefire-plugin version to use junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <argLine>${surefireArgLine}</argLine>
                     <includes>


### PR DESCRIPTION
gravitee-io/issues#4899
