### PR TITLE
chore: use https repository instead of http

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ parameters:
     description: "SecretHub Repo to use to fetch secrets ?"
 
 orbs:
-  gravitee: gravitee-io/gravitee@dev:1.0.4
+  gravitee: gravitee-io/gravitee@1.0
   secrethub: secrethub/cli@1.1.0
 
 # --- Jobs to perform all workflows

--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
     <repositories>
         <repository>
             <id>oss.sonatype.org-snapshot</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
chore: use https repository instead of http
This makes it compatible with maven>=3.8.1, which blocks http repositories