### PR TITLE
chore: upgrade jacoco and configure it to append result

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <assertj-core.version>3.12.1</assertj-core.version>
         <logback-json.version>0.1.5</logback-json.version>
     </properties>
@@ -397,7 +397,7 @@
                                 <configuration>
                                     <propertyName>surefireArgLine</propertyName>
                                     <destFile>${project.basedir}/target/jacoco.exec</destFile>
-                                    <dataFile>${project.basedir}/target/jacoco.exec</dataFile>
+                                    <append>true</append>
                                 </configuration>
                             </execution>
                             <execution>


### PR DESCRIPTION
Upgrade jacoco to v0.8.8 and configure it to make it append results in jacoco.exec file instead of replacing it.
The objective is to try to include all results of the different gateway-container tests iterations that are run to cover the different use cases we have in term of execution modes (v3, jupiter with v3 compatibility, jupiter).