### PR TITLE
fix: use nexus-plugin only in `gravitee-release` profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,12 +210,6 @@
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
                     <version>${nexus-staging-maven-plugin.version}</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>sonatype-nexus-staging</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -330,6 +324,7 @@
 
     <profiles>
         <profile>
+            <!-- Profile used to release open source modules -->
             <id>gravitee-release</id>
             <activation>
                 <property>
@@ -346,6 +341,12 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>sonatype-nexus-staging</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -363,7 +364,9 @@
             </build>
         </profile>
         <profile>
+            <!-- Profile used to release enterprise modules -->
             <id>gio-release</id>
+
             <activation>
                 <property>
                     <name>performRelease</name>


### PR DESCRIPTION

**Description**

https://github.com/gravitee-io/gravitee-parent/pull/53 move the exising nexus configuration in `pluginManagement`. But this configuration is only used for "open source" module.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `22.0.2-fix-nexus-config-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/22.0.2-fix-nexus-config-SNAPSHOT/gravitee-parent-22.0.2-fix-nexus-config-SNAPSHOT.zip)
  <!-- Version placeholder end -->
