### PR TITLE
fix: allow to skip prettier & license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <prettier-maven-plugin.version>0.21</prettier-maven-plugin.version>
         <prettier-maven-plugin.prettierJavaVersion>2.1.0</prettier-maven-plugin.prettierJavaVersion>
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+        <skip.validation>false</skip.validation>
         <versions-maven-plugin.version>2.16.0</versions-maven-plugin.version>
     </properties>
 
@@ -204,6 +205,7 @@
                             <exclude>.*/**</exclude>
                             <exclude>**/*.adoc</exclude>
                         </excludes>
+                        <skip>${skip.validation}</skip>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -266,6 +268,7 @@
                     <version>${prettier-maven-plugin.version}</version>
                     <configuration>
                         <prettierJavaVersion>${prettier-maven-plugin.prettierJavaVersion}</prettierJavaVersion>
+                        <skip>${skip.validation}</skip>
                         <inputGlobs>
                             <inputGlob>src/main/java/**/*.java</inputGlob>
                             <inputGlob>src/test/java/**/*.java</inputGlob>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Add a property to prevent prettier and license plugins from being executed