### PR TITLE
fix: update license plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,25 +193,29 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${license-maven-plugin.version}</version>
                     <configuration>
-                        <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
                         <properties>
                             <owner>The Gravitee team</owner>
                             <email>http://gravitee.io</email>
                         </properties>
-                        <excludes>
-                            <exclude>LICENSE.txt</exclude>
-                            <exclude>**/README</exclude>
-                            <exclude>src/main/packaging/**</exclude>
-                            <exclude>src/test/resources/**</exclude>
-                            <exclude>src/main/resources/**</exclude>
-                            <exclude>src/main/webapp/**</exclude>
-                            <exclude>node_modules/**</exclude>
-                            <exclude>dist/**</exclude>
-                            <exclude>.tmp/**</exclude>
-                            <exclude>.*</exclude>
-                            <exclude>.*/**</exclude>
-                            <exclude>**/*.adoc</exclude>
-                        </excludes>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                                <excludes>
+                                    <exclude>LICENSE.txt</exclude>
+                                    <exclude>**/README</exclude>
+                                    <exclude>src/main/packaging/**</exclude>
+                                    <exclude>src/test/resources/**</exclude>
+                                    <exclude>src/main/resources/**</exclude>
+                                    <exclude>src/main/webapp/**</exclude>
+                                    <exclude>node_modules/**</exclude>
+                                    <exclude>dist/**</exclude>
+                                    <exclude>.tmp/**</exclude>
+                                    <exclude>.*</exclude>
+                                    <exclude>.*/**</exclude>
+                                    <exclude>**/*.adoc</exclude>
+                                </excludes>
+                            </licenseSet>
+                        </licenseSets>
                         <skip>${skip.validation}</skip>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
**Issue**

N/A

**Description**

The current configuration for license plugin syntax has been deprecated in version 4 (https://oss.carbou.me/license-maven-plugin/#reports).

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `22.2.5-upate-maven-license-plugin-configuration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/22.2.5-upate-maven-license-plugin-configuration-SNAPSHOT/gravitee-parent-22.2.5-upate-maven-license-plugin-configuration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
