### PR TITLE
fix: update license plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
     <properties>
         <surefireArgLine></surefireArgLine>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <!-- Because of this issues.apache.org/jira/projects/MASSEMBLY/issues/MASSEMBLY-1031 we need to force the version to 3.6.0 -->
+        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>


### PR DESCRIPTION
**Description**

Force maven assembly plugin to 3.6.0

See https://issues.apache.org/jira/projects/MASSEMBLY/issues/MASSEMBLY-1031
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `22.3.0-force-maven-assembly-plugin-version-22-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/22.3.0-force-maven-assembly-plugin-version-22-x-SNAPSHOT/gravitee-parent-22.3.0-force-maven-assembly-plugin-version-22-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
