### PR TITLE
fix: avoid log4j conflict by adding an enforce rule to ban log4j depe…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee</groupId>
     <artifactId>gravitee-parent</artifactId>
-    <version>23.1.0</version>
+    <version>23.2.0</version>
     <packaging>pom</packaging>
 
     <name>Gravitee.io APIM - Parent POM</name>
@@ -132,27 +132,45 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${maven-enforcer-plugin.version}</version>
-                    <configuration>
-                        <rules>
-                            <requireReleaseDeps>
-                                <message>No Snapshots Allowed!</message>
-                                <excludes>
-                                    <!-- Workaround to break cyclic dependencies in APIM between plugins and core APIM -->
-                                    <exclude>io.gravitee.*:*:*:*:test</exclude>
-                                    <exclude>io.gravitee.apim.*:*:*:*:provided</exclude>
-                                </excludes>
-                            </requireReleaseDeps>
-                            <requireReleaseVersion>
-                                <message>No Snapshots Allowed!</message>
-                            </requireReleaseVersion>
-                        </rules>
-                    </configuration>
                     <executions>
+                        <execution>
+                            <id>enforce-no-log4j</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <bannedDependencies>
+                                        <message>No log4j allowed</message>
+                                        <excludes>
+                                            <exclude>org.apache.logging.log4j</exclude>
+                                        </excludes>
+                                    </bannedDependencies>
+                                </rules>
+                            </configuration>
+                        </execution>
                         <execution>
                             <id>enforce-no-snapshots</id>
                             <goals>
                                 <goal>enforce</goal>
                             </goals>
+                            <configuration>
+                                <!-- will be activated only in release profiles-->
+                                <skip>true</skip>
+                                <rules>
+                                    <requireReleaseDeps>
+                                        <message>No Snapshots Allowed!</message>
+                                        <excludes>
+                                            <!-- Workaround to break cyclic dependencies in APIM between plugins and core APIM -->
+                                            <exclude>io.gravitee.*:*:*:*:test</exclude>
+                                            <exclude>io.gravitee.apim.*:*:*:*:provided</exclude>
+                                        </excludes>
+                                    </requireReleaseDeps>
+                                    <requireReleaseVersion>
+                                        <message>No Snapshots Allowed!</message>
+                                    </requireReleaseVersion>
+                                </rules>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>
@@ -320,6 +338,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
@@ -361,6 +383,14 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <configuration>
+                                    <skip>false</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
@@ -402,6 +432,14 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <configuration>
+                                    <skip>false</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…ndency

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-495

**Description**

While testing the new logging endpoint of node, I ran into an issue due to a conflict between our logging lib which is logback and log4j. It appeared that a dependency on log4j was present and this is problematic. To avoid this in the future, we can rely on the maven enforcer plugin by using a ban rule. 
To make this work, I had to change the configuration to always use the enforcer plugin (not just in release profile) and only declare the "no snapshot" rule in the release profile. This way, the enforcer will always check if there is a log4j dependency not excluded and avoid it to be commited in a product relying on gravitee-parent.
The next setp will be to remove any override of the plugin in APIM (one is present here https://github.com/gravitee-io/gravitee-api-management/blob/39640925c3fc566c492196cf428e13e0e6645219/gravitee-apim-gateway/pom.xml#L76).

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `23.2.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/23.2.0/gravitee-parent-23.2.0.zip)
  <!-- Version placeholder end -->
