### PR TITLE
feat: avoid log4j conflict by adding an enforce rule to ban log4j dep…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,27 +131,45 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${maven-enforcer-plugin.version}</version>
-                    <configuration>
-                        <rules>
-                            <requireReleaseDeps>
-                                <message>No Snapshots Allowed!</message>
-                                <excludes>
-                                    <!-- Workaround to break cyclic dependencies in APIM between plugins and core APIM -->
-                                    <exclude>io.gravitee.*:*:*:*:test</exclude>
-                                    <exclude>io.gravitee.apim.*:*:*:*:provided</exclude>
-                                </excludes>
-                            </requireReleaseDeps>
-                            <requireReleaseVersion>
-                                <message>No Snapshots Allowed!</message>
-                            </requireReleaseVersion>
-                        </rules>
-                    </configuration>
                     <executions>
+                        <execution>
+                            <id>enforce-no-log4j</id>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <bannedDependencies>
+                                        <message>No log4j allowed</message>
+                                        <excludes>
+                                            <exclude>org.apache.logging.log4j</exclude>
+                                        </excludes>
+                                    </bannedDependencies>
+                                </rules>
+                            </configuration>
+                        </execution>
                         <execution>
                             <id>enforce-no-snapshots</id>
                             <goals>
                                 <goal>enforce</goal>
                             </goals>
+                            <configuration>
+                                <!-- will be activated only in release profiles-->
+                                <skip>true</skip>
+                                <rules>
+                                    <requireReleaseDeps>
+                                        <message>No Snapshots Allowed!</message>
+                                        <excludes>
+                                            <!-- Workaround to break cyclic dependencies in APIM between plugins and core APIM -->
+                                            <exclude>io.gravitee.*:*:*:*:test</exclude>
+                                            <exclude>io.gravitee.apim.*:*:*:*:provided</exclude>
+                                        </excludes>
+                                    </requireReleaseDeps>
+                                    <requireReleaseVersion>
+                                        <message>No Snapshots Allowed!</message>
+                                    </requireReleaseVersion>
+                                </rules>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>
@@ -319,6 +337,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
@@ -360,6 +382,14 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <configuration>
+                                    <skip>false</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
@@ -401,6 +431,14 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-no-snapshots</id>
+                                <configuration>
+                                    <skip>false</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
…endency

(cherry picked from commit 46981f66a9adffab54a32b44cbb1df0840cdb5ec)

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-495

**Description**

Cherry pick of PR https://github.com/gravitee-io/gravitee-parent/pull/70

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `22.4.0-feat-enforce-no-log4j-branch22-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/22.4.0-feat-enforce-no-log4j-branch22-SNAPSHOT/gravitee-parent-22.4.0-feat-enforce-no-log4j-branch22-SNAPSHOT.zip)
  <!-- Version placeholder end -->
