### PR TITLE
fix: log4j rule in maven enforcer needs to allow two library to make …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,10 +141,16 @@
                             <configuration>
                                 <rules>
                                     <bannedDependencies>
-                                        <message>No log4j allowed</message>
+                                        <message>No log4j implementations allowed</message>
                                         <excludes>
                                             <exclude>org.apache.logging.log4j</exclude>
                                         </excludes>
+                                        <includes>
+                                            <!-- log4j-api can be used by some dependencies instead of slf4j-api -->
+                                            <!-- in order to work with logback, we need to allow it and also the bridge log4j to slf4j -->
+                                            <include>org.apache.logging.log4j:log4j-api</include>
+                                            <include>org.apache.logging.log4j:log4j-to-slf4j</include>
+                                        </includes>
                                     </bannedDependencies>
                                 </rules>
                             </configuration>


### PR DESCRIPTION
…it work with some dependencies

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-495

**Description**

As some of our dependencies use log4j-api, we need to allow it and also the bridge to slf4j. With these libraries, everything is working as expected. The rule is only here to avoid log4j implementation.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `23.2.1-fix-log4j-enforcer-configuration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/23.2.1-fix-log4j-enforcer-configuration-SNAPSHOT/gravitee-parent-23.2.1-fix-log4j-enforcer-configuration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
