### PR TITLE
fix: exlude docgen config files from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,7 @@
                                     <exclude>src/main/webapp/**</exclude>
                                     <exclude>node_modules/**</exclude>
                                     <exclude>dist/**</exclude>
+                                    <exclude>.docgen/**</exclude>
                                     <exclude>.tmp/**</exclude>
                                     <exclude>.*</exclude>
                                     <exclude>.*/**</exclude>


### PR DESCRIPTION
**Issue**

gravitee doc-gen config files need to be excluded from license check to avoid having useless licenses  everywhere and in code examples in particular

**Description**

Add an eclusion for `.docgen/**`

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

