### PR TITLE
feat: add notice.txt to license exclusion config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
                                 <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
                                 <excludes>
                                     <exclude>LICENSE.txt</exclude>
+                                    <exclude>NOTICE.txt</exclude>
                                     <exclude>**/README</exclude>
                                     <exclude>src/main/packaging/**</exclude>
                                     <exclude>src/test/resources/**</exclude>


### PR DESCRIPTION
**Description**

In some project, we can add a NOTICE.txt file containing reference to other OpenSource licenses. We don't expect to put our license in this file.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

