### PR TITLE
add a deployment name for central sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
                     <configuration>
                         <publishingServerId>sonatype-nexus-staging</publishingServerId>
                         <autoPublish>true</autoPublish>
+                        <deploymentName>${project.artifactId}:${project.version}</deploymentName>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
add a deployment name for central sonatype
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `22.5.1-add-a-deployment-name-to-central-sonatype-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/22.5.1-add-a-deployment-name-to-central-sonatype-SNAPSHOT/gravitee-parent-22.5.1-add-a-deployment-name-to-central-sonatype-SNAPSHOT.zip)
  <!-- Version placeholder end -->
