### PR TITLE
fix: exclude `io.gravitee.gamma` dependencies in release validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
                                             <!-- Workaround to break cyclic dependencies in APIM between plugins and core APIM -->
                                             <exclude>io.gravitee.*:*:*:*:test</exclude>
                                             <exclude>io.gravitee.apim.*:*:*:*:provided</exclude>
+                                            <exclude>io.gravitee.gamma.*:*:*:*</exclude>
                                         </excludes>
                                     </requireReleaseDeps>
                                     <requireReleaseVersion>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

Exclude gamma dependencies from enforcer to allow using a snapshot from unreleased version

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `24.0.2-add-gamma-in-enforcer-exclusion-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/24.0.2-add-gamma-in-enforcer-exclusion-SNAPSHOT/gravitee-parent-24.0.2-add-gamma-in-enforcer-exclusion-SNAPSHOT.zip)
  <!-- Version placeholder end -->
