### PR TITLE
chore: bump prettier java plugin to 2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [25.0.0-alpha.1](https://github.com/gravitee-io/gravitee-parent/compare/24.0.0...25.0.0-alpha.1) (2026-03-16)
+
+
+### Features
+
+* **java:** upgrade to java 25, adds proc:full to address required changes to support annotation ([06e76c4](https://github.com/gravitee-io/gravitee-parent/commit/06e76c4fac985b176c6276172984c3d684108cf3))
+
+
+### BREAKING CHANGES
+
+* **java:** require java 25
+
 # [24.0.0](https://github.com/gravitee-io/gravitee-parent/compare/23.5.0...24.0.0) (2026-03-16)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <properties>
         <surefireArgLine></surefireArgLine>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <!-- Because of this issues.apache.org/jira/projects/MASSEMBLY/issues/MASSEMBLY-1031 we need to force the version to 3.6.0 -->
         <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
@@ -227,6 +227,7 @@
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
+                        <proc>full</proc>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee</groupId>
     <artifactId>gravitee-parent</artifactId>
-    <version>24.0.0</version>
+    <version>25.0.0-alpha.1</version>
     <packaging>pom</packaging>
 
     <name>Gravitee.io APIM - Parent POM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <license-maven-plugin.version>4.6</license-maven-plugin.version>
         <prettier-maven-plugin.version>0.22</prettier-maven-plugin.version>
-        <prettier-maven-plugin.prettierJavaVersion>2.7.5</prettier-maven-plugin.prettierJavaVersion>
+        <prettier-maven-plugin.prettierJavaVersion>2.8.1</prettier-maven-plugin.prettierJavaVersion>
         <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
         <skip.validation>false</skip.validation>
         <gravitee.archrules.skip>false</gravitee.archrules.skip>


### PR DESCRIPTION
Just a simple bump

on master https://github.com/gravitee-io/gravitee-parent/pull/94
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `25.0.0-mba-bump-prettier-alpha-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-parent/25.0.0-mba-bump-prettier-alpha-SNAPSHOT/gravitee-parent-25.0.0-mba-bump-prettier-alpha-SNAPSHOT.zip)
  <!-- Version placeholder end -->
